### PR TITLE
Add 'noFieldsToClear' translation for es-ES.lang spanish language file

### DIFF
--- a/es-ES.lang
+++ b/es-ES.lang
@@ -47,6 +47,7 @@ maxlength = Longitud máxima
 minOptionMessage = Este campo necesita al menos 2 opciones
 name = Nombre
 no = No
+noFieldsToClear = No hay campos para borrar
 number = Número
 off = Desactivado
 on = Activo


### PR DESCRIPTION
es-ES.lang lacked a translation for "noFieldsToClear".